### PR TITLE
fix: add internet permission to android manifest

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.tazkrtak">
+    <uses-permission android:name="android.permission.INTERNET"/>
    <application
         android:label="tazkrtak"
         android:icon="@mipmap/ic_launcher">


### PR DESCRIPTION
 * Fixes faulty android build which had no permission to use the internet as mention in [flutter realease docs](https://flutter.dev/docs/deployment/android#reviewing-the-app-manifest)

> Add the android.permission.INTERNET permission if your application code needs Internet access. The standard template does not include this tag but allows Internet access during development to enable communication between Flutter tools and a running app.
